### PR TITLE
fix: duplicate review id

### DIFF
--- a/simple_api/api/mock.js
+++ b/simple_api/api/mock.js
@@ -65,7 +65,7 @@ const movies = [
     id: "5flr8UOuJz7UuputaZ9iL",
     rating: 8,
     director: "Питер Джексон",
-    reviewIds: ["sFpB1zc2RB1_06S9PMWj4", "sFpB1zc2RB1_06S9PMWj4"],
+    reviewIds: ["sFpB1zc2RB1_06S9PMWj4", "Y16csQhvXC2VRZXiqwjWE"],
   },
   {
     title: "Оно",


### PR DESCRIPTION
@ArchieSA @SArchieEdu Артём, привет!

При получении отзывов к фильму "Властелин колец: Возвращение короля", API отдаёт два одинаковых ID. Надеюсь, что это просто опечатка и это не надо обрабатывать на клиенте. (`http://localhost:3001/api/reviews?movieId=5flr8UOuJz7UuputaZ9iL`)

Исправил на идентичный отзыв с другим ID.